### PR TITLE
notice컴포넌트 생성

### DIFF
--- a/public/assets/arrow_left.svg
+++ b/public/assets/arrow_left.svg
@@ -1,0 +1,3 @@
+<svg width="4" height="6" viewBox="0 0 4 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.25 5.5L0.75 3L3.25 0.5" stroke="#F5F5F5"/>
+</svg>

--- a/public/assets/arrow_right.svg
+++ b/public/assets/arrow_right.svg
@@ -1,0 +1,3 @@
+<svg width="4" height="6" viewBox="0 0 4 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.75 5.5L3.25 3L0.75 0.5" stroke="#F5F5F5"/>
+</svg>

--- a/src/components/Notice.module.css
+++ b/src/components/Notice.module.css
@@ -7,7 +7,7 @@
   text-decoration: none;
 }
 
-.container {
+.notice_area {
   position: absolute;
   display: inline-flex;
   width: 375px;
@@ -15,7 +15,7 @@
   left: 365px;
 }
 
-.noticeBox {
+.notice_box {
   position: relative;
   display: flex;
   width: 375px;
@@ -71,7 +71,7 @@
   cursor: pointer;
 }
 
-.contentWrap {
+.content_box {
   position: absolute;
   width: 250px;
   height: 105px;
@@ -79,7 +79,7 @@
   background: rgba(254, 254, 254, 1);
 }
 
-.contentWrap h3 {
+.content_box h3 {
   position: absolute;
   width: 215px;
   height: 15px;

--- a/src/components/Notice.module.css
+++ b/src/components/Notice.module.css
@@ -53,8 +53,10 @@
   top: 79px;
   left: 84px;
   border: 1px solid rgba(245, 245, 245, 1);
-  background: none;
   cursor: pointer;
+  background: none;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .control__right {
@@ -67,8 +69,10 @@
   top: 79px;
   left: 99px;
   border: 1px solid rgba(245, 245, 245, 1);
-  background: none;
   cursor: pointer;
+  background: none;
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .content_box {
@@ -92,6 +96,8 @@
   letter-spacing: -0.02em;
   text-align: left;
   color: rgba(36, 56, 141, 1);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .date {
@@ -120,4 +126,6 @@
   letter-spacing: -0.02em;
   text-align: left;
   color:rgba(20, 24, 44, 0.9);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/Notice.module.css
+++ b/src/components/Notice.module.css
@@ -1,0 +1,123 @@
+@import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
+
+* {
+  font-family: 'Spoqa Han Sans Neo', 'sans-serif';
+  margin: 0;
+  padding: 0;
+  text-decoration: none;
+}
+
+.container {
+  position: absolute;
+  display: inline-flex;
+  width: 375px;
+  height: 105px;
+  left: 365px;
+}
+
+.noticeBox {
+  position: relative;
+  display: flex;
+  width: 375px;
+  height: 105px;
+}
+
+.control {
+  width: 125px;
+  height: 105px;
+  background: linear-gradient(137.4deg, #263D83 3.86%, #102457 100%);
+}
+
+.control a {
+  position: absolute;
+  width: 55px;
+  height: 15px;
+  top: 15px;
+  left: 15px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 15px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color: rgba(254, 254, 254, 1);
+  text-decoration: none;
+}
+
+.control__left {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  top: 79px;
+  left: 84px;
+  border: 1px solid rgba(245, 245, 245, 1);
+  background: none;
+  cursor: pointer;
+}
+
+.control__right {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  top: 79px;
+  left: 99px;
+  border: 1px solid rgba(245, 245, 245, 1);
+  background: none;
+  cursor: pointer;
+}
+
+.contentWrap {
+  position: absolute;
+  width: 250px;
+  height: 105px;
+  left: 125px;
+  background: rgba(254, 254, 254, 1);
+}
+
+.contentWrap h3 {
+  position: absolute;
+  width: 215px;
+  height: 15px;
+  top: 15px;
+  left: 15px;
+  white-space: nowrap;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 15px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color: rgba(36, 56, 141, 1);
+}
+
+.date {
+  position: absolute;
+  width: 215px;
+  height: 11px;
+  top: 35px;
+  left: 15px;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 11px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color: rgba(135, 135, 135, 1);
+}
+
+.content {
+  position: absolute;
+  width: 215px;
+  height: 36px;
+  top: 54px;
+  left: 15px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color:rgba(20, 24, 44, 0.9);
+}

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -1,15 +1,15 @@
 import { Link } from "react-router-dom";
-import { useState, useEffect } from "react";
-import { NoticeData } from "../interfaces/interface";
+import { useState, useEffect, useCallback } from "react";
+import { ResponseNoticeData, NoticeData } from "../interfaces/interface";
+import { formatDate } from "../utils/dateUtil";
 import styles from "./Notice.module.css";
 
 function Notice() {
-  const [loading, setLoading] = useState<boolean>(true);
-  const [noticeList, setNoticeList] = useState<NoticeData[]>([]);
+  const [noticeList, setNoticeList] = useState<NoticeData[]>();
   const [noticeIndex, setNoticeIndex] = useState(0);
 
-  const parseNoticeJson = (json: NoticeData[]): NoticeData[] => {
-    return json.map((notice: NoticeData) => ({
+  const parseNoticeJson = (json: ResponseNoticeData[]): NoticeData[] => {
+    return json.map((notice) => ({
       index: notice.index,
       title: notice.title,
       content: notice.content,
@@ -23,101 +23,61 @@ function Notice() {
     ).json();
     const parsedJson = parseNoticeJson(json);
     setNoticeList(parsedJson);
-    setLoading(false);
+    console.log(json);
   };
 
   useEffect(() => {
     getNoticeList();
   }, []);
 
-  const endIndex = noticeList.length - 1;
-  const noticePrev = () => {
-    if (noticeIndex > 0) setNoticeIndex(noticeIndex - 1);
-  };
-  const noticeNext = () => {
-    if (noticeIndex < endIndex) setNoticeIndex(noticeIndex + 1);
-  };
+  const goPrev = useCallback(() => {
+    if (noticeIndex > 0) setNoticeIndex((noticeIndex) => noticeIndex - 1);
+  }, [noticeIndex]);
 
-  const formatDate = (date: Date): string => {
-    const year = String(date.getFullYear());
-    const month = String(date.getMonth()).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}.${month}.${day}`;
-  };
+  const endIndex = noticeList ? noticeList.length - 1 : 0;
+
+  const goNext = useCallback(() => {
+    if (noticeIndex < endIndex)
+      setNoticeIndex((noticeIndex) => noticeIndex + 1);
+  }, [noticeIndex, endIndex]);
 
   return (
     <div className={styles.notice_area}>
-      {loading ? (
-        <div>loading..</div>
-      ) : (
+      {noticeList ? (
         <div className={styles.notice_box}>
           <div className={styles.control}>
             <Link to={"/notice"}>NOTICE</Link>
             <button
               className={styles.control__left}
-              onClick={noticePrev}
+              onClick={goPrev}
               disabled={noticeIndex === 0}
-            >
-              <svg width="10" height="10" viewBox="0 0 10 10">
-                <line
-                  x1="6.5"
-                  y1="2.875"
-                  x2="3.5"
-                  y2="5.625"
-                  stroke="white"
-                  strokeWidth="1"
-                />
-                <line
-                  x1="6.5"
-                  y1="7.875"
-                  x2="3.5"
-                  y2="5.125"
-                  stroke="white"
-                  strokeWidth="1"
-                />
-              </svg>
-            </button>
+              style={{
+                backgroundImage: `url(${process.env.PUBLIC_URL}/assets/arrow_left.svg)`
+              }}
+            ></button>
             <button
               className={styles.control__right}
-              onClick={noticeNext}
+              onClick={goNext}
               disabled={noticeIndex === endIndex}
-            >
-              <svg width="10" height="10" viewBox="0 0 10 10">
-                <line
-                  x1="3.5"
-                  y1="2.875"
-                  x2="6.5"
-                  y2="5.625"
-                  stroke="white"
-                  strokeWidth="1"
-                />
-                <line
-                  x1="3.5"
-                  y1="7.875"
-                  x2="6.5"
-                  y2="5.125"
-                  stroke="white"
-                  strokeWidth="1"
-                />
-              </svg>
-            </button>
+              style={{
+                backgroundImage: `url(${process.env.PUBLIC_URL}/assets/arrow_right.svg)`
+              }}
+            ></button>
           </div>
           <div className={styles.content_box}>
             <Link to={"/notice"}>
-              <h3>{noticeList && noticeList[noticeIndex].title}</h3>
+              <h3>{noticeList[noticeIndex].title}</h3>
               <p className={styles.date}>
-                {noticeList &&
-                  formatDate(noticeList[noticeIndex].registrationDate)}
+                {formatDate(noticeList[noticeIndex].registrationDate)}
               </p>
               <p className={styles.content}>
-                {noticeList &&
-                  (noticeList[noticeIndex].content.length > 45
-                    ? `${noticeList[noticeIndex].content.slice(0, 45)}...`
-                    : noticeList[noticeIndex].content)}
+                {noticeList[noticeIndex].content}
               </p>
             </Link>
           </div>
         </div>
+      ) : (
+        <div>loading..</div>
       )}
     </div>
   );

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -1,0 +1,126 @@
+import { Link } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { NoticeData } from "../interfaces/interface";
+import styles from "./Notice.module.css";
+
+function Notice() {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [noticeList, setNoticeList] = useState<NoticeData[]>([]);
+  const [noticeIndex, setNoticeIndex] = useState(0);
+
+  const parseNoticeJson = (json: NoticeData[]): NoticeData[] => {
+    return json.map((notice: NoticeData) => ({
+      index: notice.index,
+      title: notice.title,
+      content: notice.content,
+      registrationDate: new Date(notice.registrationDate)
+    }));
+  };
+
+  const getNoticeList = async () => {
+    const json = await (
+      await fetch(`https://homely-susi-hyeonqyu.koyeb.app/api/notice`)
+    ).json();
+    const parsedJson = parseNoticeJson(json);
+    setNoticeList(parsedJson);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    getNoticeList();
+  }, []);
+
+  const endIndex = noticeList.length - 1;
+  const noticePrev = () => {
+    if (noticeIndex > 0) setNoticeIndex(noticeIndex - 1);
+  };
+  const noticeNext = () => {
+    if (noticeIndex < endIndex) setNoticeIndex(noticeIndex + 1);
+  };
+
+  const formatDate = (date: Date): string => {
+    const year = String(date.getFullYear());
+    const month = String(date.getMonth()).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}`;
+  };
+
+  return (
+    <div className={styles.container}>
+      {loading ? (
+        <div>loading..</div>
+      ) : (
+        <div className={styles.noticeBox}>
+          <div className={styles.control}>
+            <Link to={"/notice"}>NOTICE</Link>
+            <button
+              className={styles.control__left}
+              onClick={noticePrev}
+              disabled={noticeIndex === 0}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10">
+                <line
+                  x1="6.5"
+                  y1="2.875"
+                  x2="3.5"
+                  y2="5.625"
+                  stroke="white"
+                  strokeWidth="1"
+                />
+                <line
+                  x1="6.5"
+                  y1="7.875"
+                  x2="3.5"
+                  y2="5.125"
+                  stroke="white"
+                  strokeWidth="1"
+                />
+              </svg>
+            </button>
+            <button
+              className={styles.control__right}
+              onClick={noticeNext}
+              disabled={noticeIndex === endIndex}
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10">
+                <line
+                  x1="3.5"
+                  y1="2.875"
+                  x2="6.5"
+                  y2="5.625"
+                  stroke="white"
+                  strokeWidth="1"
+                />
+                <line
+                  x1="3.5"
+                  y1="7.875"
+                  x2="6.5"
+                  y2="5.125"
+                  stroke="white"
+                  strokeWidth="1"
+                />
+              </svg>
+            </button>
+          </div>
+          <div className={styles.contentWrap}>
+            <Link to={"/notice"}>
+              <h3>{noticeList && noticeList[noticeIndex].title}</h3>
+              <p className={styles.date}>
+                {noticeList &&
+                  formatDate(noticeList[noticeIndex].registrationDate)}
+              </p>
+              <p className={styles.content}>
+                {noticeList &&
+                  (noticeList[noticeIndex].content.length > 45
+                    ? `${noticeList[noticeIndex].content.slice(0, 45)}...`
+                    : noticeList[noticeIndex].content)}
+              </p>
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Notice;

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -23,7 +23,6 @@ function Notice() {
     ).json();
     const parsedJson = parseNoticeJson(json);
     setNoticeList(parsedJson);
-    console.log(json);
   };
 
   useEffect(() => {

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -46,11 +46,11 @@ function Notice() {
   };
 
   return (
-    <div className={styles.container}>
+    <div className={styles.notice_area}>
       {loading ? (
         <div>loading..</div>
       ) : (
-        <div className={styles.noticeBox}>
+        <div className={styles.notice_box}>
           <div className={styles.control}>
             <Link to={"/notice"}>NOTICE</Link>
             <button
@@ -102,7 +102,7 @@ function Notice() {
               </svg>
             </button>
           </div>
-          <div className={styles.contentWrap}>
+          <div className={styles.content_box}>
             <Link to={"/notice"}>
               <h3>{noticeList && noticeList[noticeIndex].title}</h3>
               <p className={styles.date}>

--- a/src/components/Notice.tsx
+++ b/src/components/Notice.tsx
@@ -10,9 +10,7 @@ function Notice() {
 
   const parseNoticeJson = (json: ResponseNoticeData[]): NoticeData[] => {
     return json.map((notice) => ({
-      index: notice.index,
-      title: notice.title,
-      content: notice.content,
+      ...notice,
       registrationDate: new Date(notice.registrationDate)
     }));
   };
@@ -29,16 +27,17 @@ function Notice() {
     getNoticeList();
   }, []);
 
-  const goPrev = useCallback(() => {
-    if (noticeIndex > 0) setNoticeIndex((noticeIndex) => noticeIndex - 1);
-  }, [noticeIndex]);
+  const goPrev = () => {
+    setNoticeIndex((prevIndex) => (prevIndex > 0 ? prevIndex - 1 : prevIndex));
+  };
 
   const endIndex = noticeList ? noticeList.length - 1 : 0;
 
-  const goNext = useCallback(() => {
-    if (noticeIndex < endIndex)
-      setNoticeIndex((noticeIndex) => noticeIndex + 1);
-  }, [noticeIndex, endIndex]);
+  const goNext = () => {
+    setNoticeIndex((prevIndex) =>
+      prevIndex < endIndex ? prevIndex + 1 : prevIndex
+    );
+  };
 
   return (
     <div className={styles.notice_area}>

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -10,3 +10,10 @@ export interface NoticeData {
   content: string;
   registrationDate: Date;
 }
+
+export interface ResponseNoticeData {
+  index: number;
+  title: string;
+  content: string;
+  registrationDate: string;
+}

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -4,16 +4,14 @@ export interface LayoutProps {
   children: ReactNode;
 }
 
-export interface NoticeData {
-  index: number;
-  title: string;
-  content: string;
-  registrationDate: Date;
-}
-
 export interface ResponseNoticeData {
   index: number;
   title: string;
   content: string;
   registrationDate: string;
+}
+
+export interface NoticeData
+  extends Omit<ResponseNoticeData, "registrationDate"> {
+  registrationDate: Date;
 }

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -3,3 +3,10 @@ import { ReactNode } from "react";
 export interface LayoutProps {
   children: ReactNode;
 }
+
+export interface NoticeData {
+  index: number;
+  title: string;
+  content: string;
+  registrationDate: Date;
+}

--- a/src/route/Home.module.css
+++ b/src/route/Home.module.css
@@ -1,4 +1,4 @@
-.homeContainer {
+.container {
   align-items: center;
 }
 
@@ -12,7 +12,7 @@
   background: rgba(245, 245, 245, 1);
 }
 
-.promotionContainer {
+.promotion_box {
   position: absolute;
   display: flex;
   width: 740px;

--- a/src/route/Home.module.css
+++ b/src/route/Home.module.css
@@ -14,6 +14,7 @@
 
 .promotionContainer {
   position: absolute;
+  display: flex;
   width: 740px;
   height: 205px;
   top: 62px;

--- a/src/route/Home.tsx
+++ b/src/route/Home.tsx
@@ -5,12 +5,12 @@ import styles from "./Home.module.css";
 
 function Home() {
   return (
-    <div className={styles.HomeContainer}>
+    <div className={styles.container}>
       <div className={styles.banner}>
         <Body />
       </div>
       <div className={styles.promotion}>
-        <div className={styles.promotionContainer}>
+        <div className={styles.promotion_box}>
           <Intro />
           <Notice />
         </div>

--- a/src/route/Home.tsx
+++ b/src/route/Home.tsx
@@ -1,5 +1,6 @@
 import Body from "../components/Body";
 import Intro from "../components/Intro";
+import Notice from "../components/Notice";
 import styles from "./Home.module.css";
 
 function Home() {
@@ -11,6 +12,7 @@ function Home() {
       <div className={styles.promotion}>
         <div className={styles.promotionContainer}>
           <Intro />
+          <Notice />
         </div>
       </div>
     </div>

--- a/src/utils/dateUtil.ts
+++ b/src/utils/dateUtil.ts
@@ -1,0 +1,6 @@
+export const formatDate = (date: Date): string => {
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+};


### PR DESCRIPTION
- 좌, 우 버튼으로 조작 가능한 공지사항을 출력하는 Notice 컴포넌트 생성 
- https://homely-susi-hyeonqyu.koyeb.app/api/notice 에서 API 통신을 통해 json을 받아오고, 파싱해서 프로퍼티를 원래의 타입으로 변환
- 타입은 interface.ts 파일에 NoticeData로 정의
- API 통신함수 getNoticeList는 의존성 없이 useEffect 훅에 넣어 렌더링시에만 호출
- API 통신을 기다리기 위한 loading, setLoading을 useState로 선언
- NoticeList 의 인덱스 조작을 위한 noticeIndex, setNoticeIndex를 useState로 선언
- 버튼을 클릭시 실행할 noticePrev, noticeNext 함수 정의
- NoticeList의 Date 타입 프로퍼티 registrationDate의 출력을 위한 formatDate 함수 정의. 출력 형태는 YYYY.MM.DD

- 버튼은 NoticeList의 첫 인덱스일 경우 좌측 버튼이, 마지막 인덱스일 경우 우측 버튼이 비활성화 되도록 설정
- 버튼 내부의 '<', '>' 모양 UI는 피그마에서 모양 보고 svg 태그로 그렸는데, 피그마에서 svg 파일로 export 가능한걸 이 풀리퀘 디스크립션 쓰다가 알게됨..
- NoticeList.content의 글자 수가 45 이상이면 slice해서 '...'와 함께 출력
- 공지사항 내용 클릭시 /News 페이지로 이동
-
![notice](https://github.com/MinQyu/Ediya-Project/assets/78997415/492decdc-fc57-4233-a4bb-2e8c69d3a4d0)
