### PR TITLE
article컴포넌트 생성

### DIFF
--- a/public/assets/+.svg
+++ b/public/assets/+.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="6" viewBox="0 0 6 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 3.02114H6M3.05331 0L3.05331 6" stroke="#F5F5F5"/>
+</svg>

--- a/src/components/Ariticle.tsx
+++ b/src/components/Ariticle.tsx
@@ -1,24 +1,29 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { Articles, Paging, ArticleData } from "../interfaces/interface";
+import {
+  ResponseArticles,
+  Articles,
+  Paging,
+  ArticleData
+} from "../interfaces/interface";
 import { formatDate } from "../utils/dateUtil";
 import styles from "./Article.module.css";
 
 function Article() {
   const [loading, setLoading] = useState<boolean>(true);
-  const [articleList, setArticleList] = useState<ArticleData>();
-  const parseArticleJson = (json: ArticleData): ArticleData => {
-    const articles: Articles[] = json.articles.map((article: Articles) => ({
-      sn: article.sn,
-      imgSrc: article.imgSrc,
-      title: article.title,
-      content: article.content,
-      registrationDate: new Date(article.registrationDate)
-    }));
+  const [articleData, setArticleData] = useState<ArticleData>();
+  const parseArticleJson = (json: {
+    articles: ResponseArticles[];
+    paging: Paging;
+  }): ArticleData => {
+    const articles: Articles[] = json.articles.map(
+      (article: ResponseArticles) => ({
+        ...article,
+        registrationDate: new Date(article.registrationDate)
+      })
+    );
     const paging: Paging = {
-      currentPage: json.paging.currentPage,
-      lastPage: json.paging.lastPage,
-      blockSize: json.paging.blockSize
+      ...json.paging
     };
     return { articles, paging };
   };
@@ -33,7 +38,7 @@ function Article() {
       currentPage: currentPage.toString()
     }).toString();
   };
-  const getArticleList = async () => {
+  const getArticleData = async () => {
     const request = makeRequest("", "", 24);
     const json = await (
       await fetch(
@@ -41,13 +46,12 @@ function Article() {
       )
     ).json();
     const parsedJson = parseArticleJson(json);
-    console.log(json);
-    setArticleList(parsedJson);
+    setArticleData(parsedJson);
     setLoading(false);
   };
 
   useEffect(() => {
-    getArticleList();
+    getArticleData();
   }, []);
 
   return (
@@ -63,26 +67,26 @@ function Article() {
           <div className={styles.article_content_wrap}>
             <div className={styles.article_content_upper}>
               <p className={styles.article_content__title}>
-                {articleList &&
-                  articleList.articles[articleList.articles.length - 1].title}
+                {articleData &&
+                  articleData.articles[articleData.articles.length - 1].title}
               </p>
               <p className={styles.article_content__date}>
-                {articleList &&
+                {articleData &&
                   formatDate(
-                    articleList.articles[articleList.articles.length - 1]
+                    articleData.articles[articleData.articles.length - 1]
                       .registrationDate
                   )}
               </p>
             </div>
             <div className={styles.article_content_lower}>
               <p className={styles.article_content__title}>
-                {articleList &&
-                  articleList.articles[articleList.articles.length - 2].title}
+                {articleData &&
+                  articleData.articles[articleData.articles.length - 2].title}
               </p>
               <p className={styles.article_content__date}>
-                {articleList &&
+                {articleData &&
                   formatDate(
-                    articleList.articles[articleList.articles.length - 2]
+                    articleData.articles[articleData.articles.length - 2]
                       .registrationDate
                   )}
               </p>

--- a/src/components/Ariticle.tsx
+++ b/src/components/Ariticle.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Articles, Paging, ArticleData } from "../interfaces/interface";
+import styles from "./Article.module.css";
+
+function Article() {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [articleList, setArticleList] = useState<ArticleData>();
+  const parseArticleJson = (json: ArticleData): ArticleData => {
+    const articles: Articles[] = json.articles.map((article: Articles) => ({
+      sn: article.sn,
+      imgSrc: article.imgSrc,
+      title: article.title,
+      content: article.content,
+      registrationDate: new Date(article.registrationDate)
+    }));
+    const paging: Paging = {
+      currentPage: json.paging.currentPage,
+      lastPage: json.paging.lastPage,
+      blockSize: json.paging.blockSize
+    };
+    return { articles, paging };
+  };
+  const makeRequest = (
+    keyword: string,
+    keywordType: string,
+    currentPage: number
+  ) => {
+    return new URLSearchParams({
+      keyword: keyword,
+      keywordType: keywordType,
+      currentPage: currentPage.toString()
+    }).toString();
+  };
+  const getArticleList = async () => {
+    const request = makeRequest("", "", 24);
+    const json = await (
+      await fetch(
+        `https://homely-susi-hyeonqyu.koyeb.app/api/article/articles?${request}`
+      )
+    ).json();
+    const parsedJson = parseArticleJson(json);
+    console.log(json);
+    setArticleList(parsedJson);
+    setLoading(false);
+  };
+  const formatDate = (date: Date): string => {
+    const year = String(date.getFullYear());
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}`;
+  };
+
+  useEffect(() => {
+    getArticleList();
+  }, []);
+
+  return (
+    <div className={styles.article_area}>
+      {loading ? (
+        <div>loading..</div>
+      ) : (
+        <div className={styles.article_box}>
+          <Link to={"/news"}>
+            <img src={process.env.PUBLIC_URL + "/assets/+.svg"}></img>
+          </Link>
+          <h3>NEWS</h3>
+          <div className={styles.article_content_wrap}>
+            <div className={styles.article_content_upper}>
+              <p className={styles.article_content__title}>
+                {articleList &&
+                  articleList.articles[articleList.articles.length - 1].title}
+              </p>
+              <p className={styles.article_content__date}>
+                {articleList &&
+                  formatDate(
+                    articleList.articles[articleList.articles.length - 1]
+                      .registrationDate
+                  )}
+              </p>
+            </div>
+            <div className={styles.article_content_lower}>
+              <p className={styles.article_content__title}>
+                {articleList &&
+                  articleList.articles[articleList.articles.length - 2].title}
+              </p>
+              <p className={styles.article_content__date}>
+                {articleList &&
+                  formatDate(
+                    articleList.articles[articleList.articles.length - 2]
+                      .registrationDate
+                  )}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Article;

--- a/src/components/Ariticle.tsx
+++ b/src/components/Ariticle.tsx
@@ -66,18 +66,21 @@ function Article() {
           <h3>NEWS</h3>
           <div className={styles.article_content_wrap}>
             {articleData &&
-              articleData.articles.slice(-2).map((article) => {
-                return (
-                  <div className={styles.article_content}>
-                    <p className={styles.article_content__title}>
-                      {article.title}
-                    </p>
-                    <p className={styles.article_content__date}>
-                      {formatDate(article.registrationDate)}
-                    </p>
-                  </div>
-                );
-              })}
+              articleData.articles
+                .slice(-2)
+                .sort((a, b) => a.sn - b.sn)
+                .map((article) => {
+                  return (
+                    <div className={styles.article_content}>
+                      <p className={styles.article_content__title}>
+                        {article.title}
+                      </p>
+                      <p className={styles.article_content__date}>
+                        {formatDate(article.registrationDate)}
+                      </p>
+                    </div>
+                  );
+                })}
           </div>
         </div>
       )}

--- a/src/components/Ariticle.tsx
+++ b/src/components/Ariticle.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Articles, Paging, ArticleData } from "../interfaces/interface";
+import { formatDate } from "../utils/dateUtil";
 import styles from "./Article.module.css";
 
 function Article() {
@@ -43,12 +44,6 @@ function Article() {
     console.log(json);
     setArticleList(parsedJson);
     setLoading(false);
-  };
-  const formatDate = (date: Date): string => {
-    const year = String(date.getFullYear());
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}.${month}.${day}`;
   };
 
   useEffect(() => {

--- a/src/components/Ariticle.tsx
+++ b/src/components/Ariticle.tsx
@@ -65,32 +65,19 @@ function Article() {
           </Link>
           <h3>NEWS</h3>
           <div className={styles.article_content_wrap}>
-            <div className={styles.article_content_upper}>
-              <p className={styles.article_content__title}>
-                {articleData &&
-                  articleData.articles[articleData.articles.length - 1].title}
-              </p>
-              <p className={styles.article_content__date}>
-                {articleData &&
-                  formatDate(
-                    articleData.articles[articleData.articles.length - 1]
-                      .registrationDate
-                  )}
-              </p>
-            </div>
-            <div className={styles.article_content_lower}>
-              <p className={styles.article_content__title}>
-                {articleData &&
-                  articleData.articles[articleData.articles.length - 2].title}
-              </p>
-              <p className={styles.article_content__date}>
-                {articleData &&
-                  formatDate(
-                    articleData.articles[articleData.articles.length - 2]
-                      .registrationDate
-                  )}
-              </p>
-            </div>
+            {articleData &&
+              articleData.articles.slice(-2).map((article) => {
+                return (
+                  <div className={styles.article_content}>
+                    <p className={styles.article_content__title}>
+                      {article.title}
+                    </p>
+                    <p className={styles.article_content__date}>
+                      {formatDate(article.registrationDate)}
+                    </p>
+                  </div>
+                );
+              })}
           </div>
         </div>
       )}

--- a/src/components/Article.module.css
+++ b/src/components/Article.module.css
@@ -58,14 +58,8 @@
   color: rgba(245, 245, 245, 1);
 }
 
-.article_content_upper p {
+.article_content p {
   display: inline-flex;
-}
-
-.article_content_lower p{
-  position: absolute;
-  display: inline-flex;
-  top: 21px;
 }
 
 .article_content__title {

--- a/src/components/Article.module.css
+++ b/src/components/Article.module.css
@@ -1,0 +1,83 @@
+
+.article_area {
+  position: absolute;
+  display: flex;
+  width: 375px;
+  height: 100px;
+  top: 105px;
+  left: 365px;
+}
+
+.article_box {
+  width: 375px;
+  height: 100px;
+  background: rgba(36, 56, 141, 1);
+}
+
+.article_box a{
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  top: 15px;
+  left: 344px;
+  border: 1px solid rgba(245, 245, 245, 1);
+  box-sizing: border-box;
+  background: none;
+}
+
+
+.article_box h3 {
+  position: absolute;
+  width: 43px;
+  height: 15px;
+  top: 15px;
+  left: 15px;
+  font-family: SpoqaHanSans;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 15px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color: rgba(254, 254, 254, 1);
+}
+
+.article_content_wrap {
+  position: absolute;
+  width: 345px;
+  height: 39px;
+  top: 45px;
+  left: 15px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 18px;
+  letter-spacing: -0.02em;
+  text-align: left;
+  color: rgba(245, 245, 245, 1);
+}
+
+.article_content_upper p {
+  display: inline-flex;
+}
+
+.article_content_lower p{
+  position: absolute;
+  display: inline-flex;
+  top: 21px;
+}
+
+.article_content__title {
+  width: 272px;
+  height: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.article_content__date {
+  position: absolute;
+  width: 63px;
+  height: 18px;
+  left: 282px;
+}

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -16,7 +16,7 @@ export interface NoticeData
   registrationDate: Date;
 }
 
-export interface Articles {
+export interface ResponseArticles {
   // 순서
   sn: number;
   // 이미지 경로
@@ -26,8 +26,14 @@ export interface Articles {
   // 기사 내용
   content: string;
   // 날짜
+  registrationDate: string;
+}
+
+export interface Articles extends Omit<ResponseArticles, "registrationDate"> {
+  // 날짜
   registrationDate: Date;
 }
+
 export interface Paging {
   // 현재 페이지
   currentPage: number;

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -10,3 +10,38 @@ export interface NoticeData {
   content: string;
   registrationDate: Date;
 }
+
+export interface Articles {
+  // 순서
+  sn: number;
+  // 이미지 경로
+  imgSrc: string;
+  // 기사 제목
+  title: string;
+  // 기사 내용
+  content: string;
+  // 날짜
+  registrationDate: Date;
+}
+export interface Paging {
+  // 현재 페이지
+  currentPage: number;
+  // 마지막 페이지
+  lastPage: number;
+  // 하단 페이지 목록에 표시되는 페이지 수
+  blockSize: number;
+}
+
+export interface ArticleData {
+  articles: Articles[];
+  paging: Paging;
+}
+
+export interface ArticleRequest {
+  // 검색어
+  keyword: string;
+  // *검색 구분 제목-'title', 내용-'content'
+  keywordType: string;
+  // *페이지 번호
+  currentPage: number;
+}

--- a/src/route/Home.tsx
+++ b/src/route/Home.tsx
@@ -1,6 +1,7 @@
 import Body from "../components/Body";
 import Intro from "../components/Intro";
 import Notice from "../components/Notice";
+import Article from "../components/Ariticle";
 import styles from "./Home.module.css";
 
 function Home() {
@@ -13,6 +14,7 @@ function Home() {
         <div className={styles.promotion_box}>
           <Intro />
           <Notice />
+          <Article />
         </div>
       </div>
     </div>


### PR DESCRIPTION
- api 통신으로 기사 데이터를 받아 최신기사 2개를 출력하는 article 컴포넌트 생성
- registrationDate를 Date 타입으로 파싱
- 타입은 interface.ts 파일에 Articles, Paging, 두 개를 합친 ArticleData로 정의
- makeRequest으로 쿼리문을 만들어 API 호출
- lastPage는 25이지만 기사가 있는 마지막 페이지는 24라서 currentPage = 24로 불러옴
- 뉴스 페이지로 이동하는 '+'모양 버튼 내 이미지는 피그마에서 svg 파일로 받아와 사용
- 기사는 날짜 역순으로 정렬되어 있어 articleList.articles의 마지막 요소와 그 전 요소를 출력
- notice를 만들때는 일정 글자 수 이상이면 자르도록 코드를 짰는데, 피그마에서 길이가 다른 두 기사 제목이 같은 길이로 잘려있는 것을 보고 찾아보다가 overflow: hidden, text-overflow: ellipsis 속성을 알게됨
- 
![아티클](https://github.com/MinQyu/Ediya-Project/assets/78997415/eabeefb2-2767-407b-bb92-ea8dd1f8ad74)
